### PR TITLE
Python: Fix docstring example for setting unit system

### DIFF
--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -16,8 +16,8 @@ each function for their respective reference.
 
 Example
     >>> import psychrolib
-    >>> # Set the unit system, for example to SI (can be either 'SI' or 'IP')
-    >>> psychrolib.SetUnitSystem('SI')
+    >>> # Set the unit system, for example to SI (can be either psychrolib.SI or psychrolib.IP)
+    >>> psychrolib.SetUnitSystem(psychrolib.SI)
     >>> # Calculate the dew point temperature for a dry bulb temperature of 25 C and a relative humidity of 80%
     >>> TDewPoint = psychrolib.GetTDewPointFromRelHum(25.0, 0.80)
     >>> print(TDewPoint)


### PR DESCRIPTION
The current example generates the following error: 
`ValueError: The system of units has to be either SI or IP.`