### PR TITLE
GetTDewPointFromVapPres: fix bounds check implementation for JS

### DIFF
--- a/src/c/psychrolib.c
+++ b/src/c/psychrolib.c
@@ -320,7 +320,7 @@ double GetTDewPointFromVapPres  // (o) Dew Point temperature in °F [IP] or °C 
   double TMidPoint = (_BOUNDS[0] + _BOUNDS[1]) / 2.;     // Midpoint of domain of validity
 
   // Bounds outside which a solution cannot be found
-  ASSERT (VapPres >= GetSatVapPres(_BOUNDS[0]) && VapPres <= GetSatVapPres(_BOUNDS[1]), "Partial pressure of water vapor is outside range of validity of equations")
+  ASSERT (VapPres < GetSatVapPres(_BOUNDS[0]) || VapPres > GetSatVapPres(_BOUNDS[1]), "Partial pressure of water vapor is outside range of validity of equations")
 
   // First guess
   double Tdp = TDryBulb;      // Calculated value of dew point temperatures, solved for iteratively in °F [IP] or °C [SI]

--- a/src/c/psychrolib.c
+++ b/src/c/psychrolib.c
@@ -320,7 +320,7 @@ double GetTDewPointFromVapPres  // (o) Dew Point temperature in °F [IP] or °C 
   double TMidPoint = (_BOUNDS[0] + _BOUNDS[1]) / 2.;     // Midpoint of domain of validity
 
   // Bounds outside which a solution cannot be found
-  ASSERT (VapPres < GetSatVapPres(_BOUNDS[0]) || VapPres > GetSatVapPres(_BOUNDS[1]), "Partial pressure of water vapor is outside range of validity of equations")
+  ASSERT (VapPres >= GetSatVapPres(_BOUNDS[0]) && VapPres <= GetSatVapPres(_BOUNDS[1]), "Partial pressure of water vapor is outside range of validity of equations")
 
   // First guess
   double Tdp = TDryBulb;      // Calculated value of dew point temperatures, solved for iteratively in °F [IP] or °C [SI]

--- a/src/fortran/psychrolib.f90
+++ b/src/fortran/psychrolib.f90
@@ -434,7 +434,7 @@ module psychrolib
     TMidPoint = (BOUNDS(2) + BOUNDS(2)) / 2.0
 
     ! Bounds outside which a solution cannot be found
-    if (VapPres <= GetSatVapPres(BOUNDS(1)) .or. VapPres >= GetSatVapPres(BOUNDS(2))) then
+    if (VapPres < GetSatVapPres(BOUNDS(1)) .or. VapPres > GetSatVapPres(BOUNDS(2))) then
       error stop "Error: partial pressure of water vapor is outside range of validity of equations"
     end if
 

--- a/src/js/psychrolib.js
+++ b/src/js/psychrolib.js
@@ -282,7 +282,7 @@ function Psychrometrics() {
   var TMidPoint = (_BOUNDS[0] + _BOUNDS[1]) / 2.;     // Midpoint of domain of validity
 
   // Bounds outside which a solution cannot be found
-  if (VapPres <= this.GetSatVapPres(_BOUNDS[0]) && VapPres >= this.GetSatVapPres(_BOUNDS[1]))
+  if (VapPres < this.GetSatVapPres(_BOUNDS[0]) || VapPres > this.GetSatVapPres(_BOUNDS[1]))
     throw new Error("Partial pressure of water vapor is outside range of validity of equations");
 
   // First guess


### PR DESCRIPTION
This PR fixes #6 where the bounds check for the JS was not implemented correctly -- the logical OR should have been used in the if block as done in the other implementations so that exception is triggered if the vapour pressure is outside the lower or upper bound.