### PR TITLE
CI: Constrain numpy version to 1.15.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 before_install:
   - pip freeze
-  - pip uninstall numpy && pip install numpy==1.15.4 # FIXME: Temporary fix as f2py is buggy on numpy 1.16.0
+  - pip uninstall numpy -y && pip install numpy==1.15.4 # FIXME: Temporary fix as f2py is buggy on numpy 1.16.0
   - sudo apt-get install gfortran
   - pip install Sphinx sphinx_bootstrap_theme sphinx-autodoc-typehints m2r cffi
 


### PR DESCRIPTION
This mitigates the current bug with the latest version of `f2py` in numpy 1.16.0 (for more see https://github.com/numpy/numpy/issues/12796) simply by constraining the version of numpy to 1.15.4 for now -- will revert to default floating version once bug fixed upstream.