### PR TITLE
Djt/vba convergence test

### DIFF
--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -271,7 +271,7 @@ End Sub
 '
 Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -148 To 392 Step 2
-    For rh = 0 To 1 Step 0.1
+    For RelHum = 0 To 1 Step 0.1
       For p = 8.6 To 17.4 Step 0.8
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
       Next p

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -27,6 +27,7 @@ Sub RunAllTests()
   Call test_GetStandardAtmTemperature
   Call test_SeaLevel_Station_Pressure
   Call test_AllPsychrometrics
+  Call test_GetTDewPointFromVapPres_convergence
   Debug.Print "# of tests run   :", TestCount
   Debug.Print "# of issues found:", IssueCount
 End Sub
@@ -261,3 +262,20 @@ Sub test_AllPsychrometrics()
   Call TestExpression("CalcPsychrometricsFromRelHum", TWetBulb, 65, abst:=0.1)
 End Sub
 
+  
+'##############################################################################
+' Test of the convergence of the NR method in GetTDewPointFromVapPres
+' over a wide range of inputs
+' This test was known problem in versions of PsychroLib <= 2.0.0
+'##############################################################################
+'
+Sub test_GetTDewPointFromVapPres_convergence()
+  For TDryBulb = -148 To 392 Step 2
+    For rh = 0 To 1 Step 0.1
+      For p = 8.6 To 17.4 Step 0.8
+        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
+      Next p
+    Next rh
+  Next TDryBulb
+  Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)
+End Sub

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -272,7 +272,7 @@ End Sub
 Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -148 To 392 Step 2
     For RelHum = 0 To 1 Step 0.1
-      For p = 8.6 To 17.4 Step 0.8
+      For Pressure = 8.6 To 17.4 Step 0.8
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
       Next p
     Next rh

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -274,7 +274,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
     For RelHum = 0 To 1 Step 0.1
       For Pressure = 8.6 To 17.4 Step 0.8
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
-      Next p
+      Next Pressure
     Next rh
   Next TDryBulb
   Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -273,7 +273,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -148 To 392 Step 2
     For RelHum = 0 To 1 Step 0.1
       For Pressure = 8.6 To 17.4 Step 0.8
-        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
+        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
       Next p
     Next rh
   Next TDryBulb

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -275,7 +275,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
       For Pressure = 8.6 To 17.4 Step 0.8
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
       Next Pressure
-    Next rh
+    Next RelHum
   Next TDryBulb
   Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)
 End Sub

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -270,7 +270,7 @@ End Sub
 '
 Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -100 To 200 Step 1
-    For rh = 0 To 1 Step 0.1
+    For RelHum = 0 To 1 Step 0.1
       For p = 60000 To 120000 Step 10000
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
       Next p

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -27,6 +27,7 @@ Sub RunAllTests()
   Call test_GetStandardAtmTemperature
   Call test_SeaLevel_Station_Pressure
   Call test_AllPsychrometrics
+  Call test_GetTDewPointFromVapPres_convergence
   Debug.Print "# of tests run   :", TestCount
   Debug.Print "# of issues found:", IssueCount
 End Sub
@@ -260,4 +261,22 @@ Sub test_AllPsychrometrics()
   Call CalcPsychrometricsFromRelHum(TDryBulb, RelHum, AtmPres, HumRatio, TWetBulb, TDewPoint, VapPres, MoistAirEnthalpy, MoistAirVolume, DegreeOfSaturation)
   Call TestExpression("CalcPsychrometricsFromRelHum", TWetBulb, 20, abst:=0.1)
 End Sub
+
+'##############################################################################
+' Test of the convergence of the NR method in GetTDewPointFromVapPres
+' over a wide range of inputs
+' This test was known problem in versions of PsychroLib <= 2.0.0
+'##############################################################################
+'
+Sub test_GetTDewPointFromVapPres_convergence()
+  For TDryBulb = 100 To 200 Step 1
+    For rh = 0 To 1 Step 0.1
+      For p = 60000 To 120000 Step 10000
+        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
+      Next p
+    Next rh
+  Next TDryBulb
+  Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)
+End Sub
+
 

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -272,7 +272,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -100 To 200 Step 1
     For RelHum = 0 To 1 Step 0.1
       For Pressure = 60000 To 120000 Step 10000
-        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
+        TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
       Next p
     Next rh
   Next TDryBulb

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -271,7 +271,7 @@ End Sub
 Sub test_GetTDewPointFromVapPres_convergence()
   For TDryBulb = -100 To 200 Step 1
     For RelHum = 0 To 1 Step 0.1
-      For p = 60000 To 120000 Step 10000
+      For Pressure = 60000 To 120000 Step 10000
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)
       Next p
     Next rh

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -273,7 +273,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
     For RelHum = 0 To 1 Step 0.1
       For Pressure = 60000 To 120000 Step 10000
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
-      Next p
+      Next Pressure
     Next rh
   Next TDryBulb
   Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -274,7 +274,7 @@ Sub test_GetTDewPointFromVapPres_convergence()
       For Pressure = 60000 To 120000 Step 10000
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, RelHum, Pressure)
       Next Pressure
-    Next rh
+    Next RelHum
   Next TDryBulb
   Call TestExpression("GetTDewPointFromVapPres convergence test", 1, 1, abst:=0.1)
 End Sub

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -269,7 +269,7 @@ End Sub
 '##############################################################################
 '
 Sub test_GetTDewPointFromVapPres_convergence()
-  For TDryBulb = 100 To 200 Step 1
+  For TDryBulb = -100 To 200 Step 1
     For rh = 0 To 1 Step 0.1
       For p = 60000 To 120000 Step 10000
         TWetBulb = GetTWetBulbFromRelHum(TDryBulb, rh, p)


### PR DESCRIPTION
This PR adds test to check that the NR in GetTDewPointFromVapPres converges. This test was known problem in versions of PsychroLib <= 2.0.0