### PR TITLE
Add inverse function for GetMoistAirVolume

### DIFF
--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -1169,7 +1169,7 @@ def GetMoistAirVolume(TDryBulb: float, HumRatio: float, Pressure: float) -> floa
         MoistAirVolume = R_DA_SI * GetTKelvinFromTCelsius(TDryBulb) * (1 + 1.607858 * BoundedHumRatio) / Pressure
     return MoistAirVolume
 
-def GetTDryBulbFromMoistAirVolume(MoistAirVolume: float, HumRatio: float, Pressure: float) -> float:
+def GetTDryBulbFromMoistAirVolumeAndHumRatio(MoistAirVolume: float, HumRatio: float, Pressure: float) -> float:
     """
     Return dry-bulb temperature given
     moist air specific volume, humidity ratio, and pressure.

--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -51,7 +51,12 @@ from typing import Optional
 # Global constants
 #######################################################################################################
 
-R_DA_IP =  53.350
+# Zero degree Fahrenheit (°F) expressed as degree Rankine (°R)
+ZERO_FAHRENHEIT_AS_RANKINE = 459.67
+# Zero degree Celsius (°C) expressed as Kelvin (K)
+ZERO_CELSIUS_AS_KELVIN = 273.15
+
+R_DA_IP = 53.350
 """float: Universal gas constant for dry air (IP version)
 
     Units:
@@ -189,11 +194,25 @@ def GetTRankineFromTFahrenheit(TFahrenheit: float) -> float:
         Exact conversion.
 
     """
-    # Zero degree Fahrenheit (°F) expressed as degree Rankine (°R)
-    ZERO_FAHRENHEIT_AS_RANKINE = 459.67
-
     TRankine = TFahrenheit + ZERO_FAHRENHEIT_AS_RANKINE
     return TRankine
+
+def GetTFahrenheitFromTRankine(TRankine: float) -> float:
+    """
+    Utility function to convert temperature to degree Fahrenheit (°F)
+    given temperature in degree Rankine (°R).
+
+    Args:
+        TRankine: Temperature in degree Rankine (°R)
+
+    Returns:
+        Temperature in degree Fahrenheit (°F)
+
+    Notes:
+        Exact conversion.
+
+    """
+    return TRankine - ZERO_FAHRENHEIT_AS_RANKINE
 
 def GetTKelvinFromTCelsius(TCelsius: float) -> float:
     """
@@ -210,11 +229,25 @@ def GetTKelvinFromTCelsius(TCelsius: float) -> float:
         Exact conversion.
 
     """
-    # Zero degree Celsius (°C) expressed as Kelvin (K)
-    ZERO_CELSIUS_AS_KELVIN = 273.15
-
     TKelvin = TCelsius + ZERO_CELSIUS_AS_KELVIN
     return TKelvin
+
+def GetTCelsiusFromTKelvin(TKelvin: float) -> float:
+    """
+    Utility function to convert temperature to degree Celsius (°C)
+    given temperature in Kelvin (K).
+
+    Args:
+        TKelvin: Temperature in Kelvin (K)
+
+    Returns:
+        Temperature in degree Celsius (°C)
+
+    Notes:
+        Exact conversion.
+
+    """
+    return TKelvin - ZERO_CELSIUS_AS_KELVIN
 
 
 #######################################################################################################

--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -51,10 +51,27 @@ from typing import Optional
 # Global constants
 #######################################################################################################
 
-# Zero degree Fahrenheit (°F) expressed as degree Rankine (°R)
 ZERO_FAHRENHEIT_AS_RANKINE = 459.67
-# Zero degree Celsius (°C) expressed as Kelvin (K)
+"""float: Zero degree Fahrenheit (°F) expressed as degree Rankine (°R)
+
+    Units:
+        °R
+
+    Reference:
+        ASHRAE Handbook - Fundamentals (2017) ch. 39
+
+"""
+
 ZERO_CELSIUS_AS_KELVIN = 273.15
+"""float: Zero degree Celsius (°C) expressed as Kelvin (K)
+
+    Units:
+        K
+
+    Reference:
+        ASHRAE Handbook - Fundamentals (2017) ch. 39
+
+"""
 
 R_DA_IP = 53.350
 """float: Universal gas constant for dry air (IP version)
@@ -1171,8 +1188,7 @@ def GetMoistAirVolume(TDryBulb: float, HumRatio: float, Pressure: float) -> floa
 
 def GetTDryBulbFromMoistAirVolumeAndHumRatio(MoistAirVolume: float, HumRatio: float, Pressure: float) -> float:
     """
-    Return dry-bulb temperature given
-    moist air specific volume, humidity ratio, and pressure.
+    Return dry-bulb temperature given moist air specific volume, humidity ratio, and pressure.
 
     Args:
         MoistAirVolume: Specific volume of moist air in ft³ lb⁻¹ of dry air [IP] or in m³ kg⁻¹ of dry air [SI]
@@ -1197,14 +1213,12 @@ def GetTDryBulbFromMoistAirVolumeAndHumRatio(MoistAirVolume: float, HumRatio: fl
 
     if isIP():
         TDryBulb = GetTFahrenheitFromTRankine(
-            MoistAirVolume
-            * (144 * Pressure)
+            MoistAirVolume * (144 * Pressure)
             / (R_DA_IP * (1 + 1.607858 * BoundedHumRatio))
         )
     else:
         TDryBulb = GetTCelsiusFromTKelvin(
-            MoistAirVolume
-            * Pressure
+            MoistAirVolume * Pressure
             / (R_DA_SI * (1 + 1.607858 * BoundedHumRatio))
         )
     return TDryBulb

--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -1169,6 +1169,46 @@ def GetMoistAirVolume(TDryBulb: float, HumRatio: float, Pressure: float) -> floa
         MoistAirVolume = R_DA_SI * GetTKelvinFromTCelsius(TDryBulb) * (1 + 1.607858 * BoundedHumRatio) / Pressure
     return MoistAirVolume
 
+def GetTDryBulbFromMoistAirVolume(MoistAirVolume: float, HumRatio: float, Pressure: float) -> float:
+    """
+    Return dry-bulb temperature given
+    moist air specific volume, humidity ratio, and pressure.
+
+    Args:
+        MoistAirVolume: Specific volume of moist air in ft³ lb⁻¹ of dry air [IP] or in m³ kg⁻¹ of dry air [SI]
+        HumRatio : Humidity ratio in lb_H₂O lb_Air⁻¹ [IP] or kg_H₂O kg_Air⁻¹ [SI]
+        Pressure : Atmospheric pressure in Psi [IP] or Pa [SI]
+
+    Returns:
+        TDryBulb : Dry-bulb temperature in °F [IP] or °C [SI]
+
+    Reference:
+        ASHRAE Handbook - Fundamentals (2017) ch. 1 eqn 26
+
+    Notes:
+        In IP units, R_DA_IP / 144 equals 0.370486 which is the coefficient appearing in eqn 26
+        The factor 144 is for the conversion of Psi = lb in⁻² to lb ft⁻².
+        Based on the `GetMoistAirVolume` function, rearranged for dry-bulb temperature.
+
+    """
+    if HumRatio < 0:
+        raise ValueError("Humidity ratio is negative")
+    BoundedHumRatio = max(HumRatio, MIN_HUM_RATIO)
+
+    if isIP():
+        TDryBulb = GetTFahrenheitFromTRankine(
+            MoistAirVolume
+            * (144 * Pressure)
+            / (R_DA_IP * (1 + 1.607858 * BoundedHumRatio))
+        )
+    else:
+        TDryBulb = GetTCelsiusFromTKelvin(
+            MoistAirVolume
+            * Pressure
+            / (R_DA_SI * (1 + 1.607858 * BoundedHumRatio))
+        )
+    return TDryBulb
+
 def GetMoistAirDensity(TDryBulb: float, HumRatio: float, Pressure:float) -> float:
     """
     Return moist air density given humidity ratio, dry bulb temperature, and pressure.


### PR DESCRIPTION
Simple addition of a new method **`GetTDryBulbFromMoistAirVolume`**, to return dry-bulb temperature given moist air specific volume, humidity ratio, and pressure, and inverse transformations for temperature conversions: `GetTFahrenheitFromTRankine` and `GetTCelsiusFromTKelvin`

