### PR TITLE
psychrolib.js: fix comment on GetHumRatioFromRelHum() arguments

### DIFF
--- a/src/js/psychrolib.js
+++ b/src/js/psychrolib.js
@@ -476,7 +476,7 @@ function Psychrometrics() {
   // Return humidity ratio given dry-bulb temperature, relative humidity, and pressure.
   // Reference: ASHRAE Handbook - Fundamentals (2017) ch. 1
   this.GetHumRatioFromRelHum = function // (o) Humidity Ratio in lb_H₂O lb_Air⁻¹ [IP] or kg_H₂O kg_Air⁻¹ [SI]
-    ( TDryBulb                          // (i) Dry bulb temperature [F]
+    ( TDryBulb                          // (i) Dry bulb temperature in °F [IP] or °C [SI]
     , RelHum                            // (i) Relative humidity [0-1]
     , Pressure                          // (i) Atmospheric pressure in Psi [IP] or Pa [SI]
     ) {


### PR DESCRIPTION
I think TDryBulb is given in °F or °C to this.GetHumRatioFromRelHum, depending on the used unit system, similar to all other functions. Also the comment on this.GetVapPresFromRelHum, which is called from this function, says so.