### PR TITLE
Update lic headers

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 D. Thevenard and D. Meyer.
+Copyright (c) 2018-2020 The PsychroLib Contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,17 +18,15 @@ Examples on how to use PsychroLib in all the supported languages are described i
 ## Installing
 
 - Python: from the [Python Package Index (PyPI)](https://pypi.org/project/PsychroLib/).
-
 - C# (.NET): from the [NuGet package](https://www.nuget.org/packages/PsychroLib/) manager or clone the repository, and bundle according to your requirements.
-
 - C, Fortran and JavaScript: clone the repository, and bundle according to your requirements.
-
 - VBA/Excel: download the ready-made spreadsheets from the [release tab](https://github.com/psychrometrics/psychrolib/releases).
+- R: from the [Comprehensive R Archive Network (CRAN)](https://cran.r-project.org/package=psychrolib).
 
 
 ## Citing
 
-If you are using PsychroLib, please cite the specific version you are using (https://doi.org/10.5281/zenodo.2537945), and the summary paper (https://doi.org/10.21105/joss.01137).
+If you are using PsychroLib, please cite the specific version you are using (select from the list at https://doi.org/10.5281/zenodo.2537945) and the summary paper (https://doi.org/10.21105/joss.01137).
 
 
 ## Contributing
@@ -36,15 +34,25 @@ If you are using PsychroLib, please cite the specific version you are using (htt
 If you are looking to contribute, please read our [Contributors' guide](CONTRIBUTING.md) for details.
 
 
+## Development
+
+If you would like to know more about specific development guidelines and testing, please refer to our [development notes](DEVELOP.md).
+
+
 ## Copyright and license
 
-Copyright 2018 D. Thevenard and D. Meyer for the current library implementation.
+Copyright 2018-2020 [The PsychroLib Contributors](https://github.com/psychrometrics/psychrolib/graphs/contributors) for the current library implementation.
 
 Copyright 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook — Fundamentals Chapter 1.
 
-Licensed under the [MIT License](LICENSE.txt).
+Software licensed under the [MIT License](LICENSE.txt).
 
 
 ## Acknowledgements
 
-Many thanks to [@tom--](https://github.com/tom--) for his suggestions with the original JavaScript library implementation and [@DJGosnell](https://github.com/DJGosnell) for the C# port.
+Special thanks to:
+- [@tom--](https://github.com/tom--) for his suggestions with the original JavaScript library implementation
+- [@DJGosnell](https://github.com/DJGosnell) for the C# port.
+- [@hongyuanjia](https://github.com/hongyuanjia) and [@banfelder](https://github.com/banfelder) for the R port.
+
+For the full list of contributors, please see the [contributors page](https://github.com/psychrometrics/psychrolib/graphs/contributors).

--- a/src/c/psychrolib.c
+++ b/src/c/psychrolib.c
@@ -1,7 +1,7 @@
-/**
- * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
- * Copyright (c) 2018 D. Thevenard and D. Meyer for the current library implementation
- * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
+/*
+ * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+ * Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+ * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
  * Licensed under the MIT License.
  *
  * Module overview
@@ -25,7 +25,7 @@
  *
  * Copyright
  *  - For the current library implementation
- *     Copyright (c) 2018 D. Thevenard and D. Meyer.
+ *     Copyright (c) 2018-2020 The PsychroLib Contributors.
  *  - For equations and coefficients published ASHRAE Handbook — Fundamentals, Chapter 1
  *     Copyright (c) 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org)
  *

--- a/src/c/psychrolib.h
+++ b/src/c/psychrolib.h
@@ -1,5 +1,9 @@
-// PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-// Copyright(c) 2018 D.Thevenard and D.Meyer. Licensed under the MIT License.
+/*
+ * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+ * Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+ * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
+ * Licensed under the MIT License.
+*/
 
 /******************************************************************************************************
  * Helper functions

--- a/src/c_sharp/PsychroLib/psychrolib.cs
+++ b/src/c_sharp/PsychroLib/psychrolib.cs
@@ -1,10 +1,9 @@
 ﻿/*
- * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
- * Copyright (c) 2018 D. Thevenard and D. Meyer, D. Gosnell for the current library implementation
- * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
- * Ported to C# by https://github.com/DJGosnell
+ * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+ * Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+ * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
  * Licensed under the MIT License.
- */
+*/
 
 using System;
 

--- a/src/fortran/psychrolib.f90
+++ b/src/fortran/psychrolib.f90
@@ -1,6 +1,6 @@
-! PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-! Copyright (c) 2018 D. Thevenard and D. Meyer for the current library implementation
-! Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
+! PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+! Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+! Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
 ! Licensed under the MIT License.
 
 module psychrolib
@@ -24,7 +24,7 @@ module psychrolib
   !+
   !+ Copyright
   !+  - For the current library implementation
-  !+     Copyright (c) 2018 D. Thevenard and D. Meyer.
+  !+     Copyright (c) 2018-2020 The PsychroLib Contributors.
   !+  - For equations and coefficients published ASHRAE Handbook — Fundamentals, Chapter 1
   !+     Copyright (c) 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org)
   !+

--- a/src/js/psychrolib.js
+++ b/src/js/psychrolib.js
@@ -1,7 +1,7 @@
-/**
- * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
- * Copyright (c) 2018 D. Thevenard and D. Meyer for the current library implementation
- * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
+/*
+ * PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+ * Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+ * Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
  * Licensed under the MIT License.
  */
 
@@ -29,7 +29,7 @@ function Psychrometrics() {
    *
    * Copyright
    *  - For the current library implementation
-   *     Copyright (c) 2018 D. Thevenard and D. Meyer.
+   *     Copyright (c) 2018-2020 The PsychroLib Contributors.
    *  - For equations and coefficients published ASHRAE Handbook — Fundamentals, Chapter 1
    *     Copyright (c) 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org)
    *

--- a/src/python/psychrolib.py
+++ b/src/python/psychrolib.py
@@ -1,6 +1,6 @@
-# PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-# Copyright (c) 2018 D. Thevenard and D. Meyer for the current library implementation
-# Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
+# PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+# Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+# Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
 # Licensed under the MIT License.
 
 """ psychrolib.py
@@ -25,7 +25,7 @@ Example
 
 Copyright
     - For the current library implementation
-        Copyright (c) 2018 D. Thevenard and D. Meyer.
+        Copyright (c) 2018-2020 The PsychroLib Contributors.
     - For equations and coefficients published ASHRAE Handbook — Fundamentals, Chapter 1
         Copyright (c) 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org)
 

--- a/src/vba/psychrolib.bas
+++ b/src/vba/psychrolib.bas
@@ -1,6 +1,6 @@
-' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-' Copyright (c) 2018 D. Thevenard and D. Meyer for the current library implementation
-' Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients
+' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+' Copyright (c) 2018-2020 The PsychroLib Contributors for the current library implementation.
+' Copyright (c) 2017 ASHRAE Handbook — Fundamentals for ASHRAE equations and coefficients.
 ' Licensed under the MIT License.
 '
 ' psychrolib.vba
@@ -26,7 +26,7 @@
 '
 ' Copyright
 '     - For the current library implementation
-'         Copyright (c) 2018 D. Thevenard and D. Meyer.
+'         Copyright (c) 2018-2020 The PsychroLib Contributors.
 '     - For equations and coefficients published ASHRAE Handbook — Fundamentals, Chapter 1
 '         Copyright (c) 2017 ASHRAE Handbook — Fundamentals (https://www.ashrae.org)
 '

--- a/tests/c_sharp/PsychroLib.Tests/PsychroLibUnitTests.cs
+++ b/tests/c_sharp/PsychroLib.Tests/PsychroLibUnitTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+// Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
+using System;
 using NUnit.Framework;
 
 namespace PsychroLib.Tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+# PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+# Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
 
 import sys
 from pathlib import Path

--- a/tests/js/test_psychrolib_ip.js
+++ b/tests/js/test_psychrolib_ip.js
@@ -1,4 +1,6 @@
-// Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+// PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+// Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 // Test of PsychroLib in IP units.
 
 const assert = require('assert');

--- a/tests/js/test_psychrolib_si.js
+++ b/tests/js/test_psychrolib_si.js
@@ -1,4 +1,6 @@
-// Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+// PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+// Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 // Test of PsychroLib in SI units.
 
 const assert = require('assert');

--- a/tests/test_psychrolib_ip.py
+++ b/tests/test_psychrolib_ip.py
@@ -1,4 +1,6 @@
-# Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+# PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+# Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 # Test of PsychroLib in IP units for Python, C, and Fortran.
 
 import numpy as np

--- a/tests/test_psychrolib_si.py
+++ b/tests/test_psychrolib_si.py
@@ -1,4 +1,6 @@
-# Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+# PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+# Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 # Test of PsychroLib in SI units for Python, C, and Fortran.
 
 import numpy as np

--- a/tests/vba/test_psychrolib_ip.bas
+++ b/tests/vba/test_psychrolib_ip.bas
@@ -1,5 +1,6 @@
-' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-' Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+' Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 ' Test of PsychroLib in IP units
 '
 ' This series of test is modeled after the ones used with pytest

--- a/tests/vba/test_psychrolib_si.bas
+++ b/tests/vba/test_psychrolib_si.bas
@@ -1,5 +1,6 @@
-' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib)
-' Copyright (c) 2018 D. Thevenard and D. Meyer. Licensed under the MIT License.
+' PsychroLib (version 2.3.0) (https://github.com/psychrometrics/psychrolib).
+' Copyright (c) 2018-2020 The PsychroLib Contributors. Licensed under the MIT License.
+
 ' Test of PsychroLib in SI units
 '
 ' This series of test is modeled after the ones used with pytest


### PR DESCRIPTION
This PR simplify the copyright holder at the top of source file with "The PsychroLib Contributors" so that we have a consistent way to name the copyright holder across source files from different contributors. The list of contributions can then be viewed directly on GitHub at https://github.com/psychrometrics/psychrolib/graphs/contributors.

@didierthevenard please let me know if this is OK.