### PR TITLE
Fix README links in R implementation deploy tool

### DIFF
--- a/src/r/tools/deploy.R
+++ b/src/r/tools/deploy.R
@@ -70,7 +70,7 @@ update_links <- function () {
     ## files
     repo <- "https://github.com/psychrometrics/psychrolib"
     readme <- gsub("(\\[.+\\])\\(LICENSE.txt\\)", "\\1(LICENSE)", readme)
-    readme <- gsub("(\\[.+\\])\\((.+\\.md)\\)", paste0("\\1(", repo, "\\2)"), readme)
+    readme <- gsub("(\\[.+\\])\\((.+\\.md)\\)", paste0("\\1(", repo, "/blob/master/\\2)"), readme)
     writeLines(readme, "README.md")
 }
 


### PR DESCRIPTION
## Pull request view

The URL construction in updating links in `src/r/tools/deploy.R` is incorrect. The generated links were something like `https://github.com/psychrometrics/psychrolibDEVELOP.md`, which is invalid.

Unfortunately, existing test platform cannot capture this type of error, except machines on CRAN. This PR fixes the issue by adding `/blob/master/` between the GitHub repo link and target file name.