### PR TITLE
Update DOI and LICENSE for CRAN submission

### DIFF
--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -2,15 +2,17 @@ Package: psychrolib
 Type: Package
 Title: Psychrometric Properties of Moist and Dry Air
 Version: 2.4.0
-Authors@R: c(person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
-             person("Jason", "Banfelder", email = "jason@banfelder.net", role = "aut"),
-             person("David", "Meyer", role = "aut", comment = c(ORCID = "0000-0002-7071-7547")),
-             person("Didier", "Thevenard", role = "aut", comment = c(ORCID = "0000-0002-0749-6841")))
+Authors@R: c(
+      person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
+             comment = "Authors listed at https://github.com/psychrometrics/psychrolib/graphs/contributors"),
+      person(family = "ASHRAE", role = c("cph")
+             comment = "Copyright 2017 ASHRAE Handbook  Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook  Fundamentals Chapter 1."))
+Maintainer: Hongyuan Jia <hongyuan.jia@bears-berkeley.sg>
 Description:
-    'PsychroLib'
-    <https://github.com/psychrometrics/psychrolib> to calculate psychrometric
-    properties of moist and dry air in both metric (SI) and imperial
-    (IP) systems of units. References: Meyer, D. and Thevenard, D (2019) <doi.org/10.21105/joss.01137>.
+    'PsychroLib' <https://github.com/psychrometrics/psychrolib> is a library of
+    functions to enable the calculation properties of moist and dry air in both
+    metric (SI) and imperial (IP) systems of units. References: Meyer, D. and
+    Thevenard, D (2019) <doi.org/10.21105/joss.01137>.
 Depends:
     R (>= 3.0.0)
 Imports:

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 2.4.0
 Authors@R: c(
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
              comment = "Authors listed at https://github.com/psychrometrics/psychrolib/graphs/contributors"),
-      person(family = "ASHRAE", role = c("cph")
+      person(family = "ASHRAE", role = c("cph"),
              comment = "Copyright 2017 ASHRAE Handbook  Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook  Fundamentals Chapter 1."))
 Maintainer: Hongyuan Jia <hongyuan.jia@bears-berkeley.sg>
 Description:

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg",
              person("David", "Meyer", role = "aut", comment = c(ORCID = "0000-0002-7071-7547")),
              person("Didier", "Thevenard", role = "aut", comment = c(ORCID = "0000-0002-0749-6841")))
 Description:
-    R implementation of 'PsychroLib'
+    Implementation of 'PsychroLib'
     <https://github.com/psychrometrics/psychrolib> to calculate psychrometric
     properties of moist and dry air in both metric (SI) and imperial
     (IP) systems of units.

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -3,6 +3,7 @@ Type: Package
 Title: Psychrometric Properties of Moist and Dry Air
 Version: 2.4.0
 Authors@R: c(
+      person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
              email = "hongyuan.jia@bears-berkeley.sg",
              comment = "Authors listed at https://github.com/psychrometrics/psychrolib/graphs/contributors"),

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg",
              person("David", "Meyer", role = "aut", comment = c(ORCID = "0000-0002-7071-7547")),
              person("Didier", "Thevenard", role = "aut", comment = c(ORCID = "0000-0002-0749-6841")))
 Description:
-    Implementation of 'PsychroLib'
+    'PsychroLib'
     <https://github.com/psychrometrics/psychrolib> to calculate psychrometric
     properties of moist and dry air in both metric (SI) and imperial
     (IP) systems of units. References: Meyer, D. and Thevenard, D (2019) <doi.org/10.21105/joss.01137>.

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -5,10 +5,9 @@ Version: 2.4.0
 Authors@R: c(
       person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
-             email = "hongyuan.jia@bears-berkeley.sg",
-             comment = "Authors listed at https://github.com/psychrometrics/psychrolib/graphs/contributors"),
+             comment = "Authors listed in inst/PSYCHROLIB_AUTHORS.txt"),
       person(family = "ASHRAE", role = c("cph"),
-             comment = "Copyright 2017 ASHRAE Handbook  Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook  Fundamentals Chapter 1."))
+             comment = "Copyright 2017 ASHRAE Handbook Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook Fundamentals Chapter 1."))
 Maintainer: Hongyuan Jia <hongyuan.jia@bears-berkeley.sg>
 Description:
     'PsychroLib' <https://github.com/psychrometrics/psychrolib> is a library of

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -4,6 +4,7 @@ Title: Psychrometric Properties of Moist and Dry Air
 Version: 2.4.0
 Authors@R: c(
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
+             email = "hongyuan.jia@bears-berkeley.sg",
              comment = "Authors listed at https://github.com/psychrometrics/psychrolib/graphs/contributors"),
       person(family = "ASHRAE", role = c("cph"),
              comment = "Copyright 2017 ASHRAE Handbook  Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook  Fundamentals Chapter 1."))

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -10,7 +10,7 @@ Description:
     Implementation of 'PsychroLib'
     <https://github.com/psychrometrics/psychrolib> to calculate psychrometric
     properties of moist and dry air in both metric (SI) and imperial
-    (IP) systems of units.
+    (IP) systems of units. References: Meyer, D. and Thevenard, D (2019) <doi.org/10.21105/joss.01137>.
 Depends:
     R (>= 3.0.0)
 Imports:

--- a/src/r/inst/CITATION
+++ b/src/r/inst/CITATION
@@ -11,6 +11,6 @@ bibentry(
     number = "33",
     pages = "1137",
     year = "2019",
-    doi = "doi.org/10.21105/joss.01137",
+    doi = "10.21105/joss.01137",
     textVersion = "Meyer, D., & Thevenard, D.  (2019). PsychroLib: a library of psychrometric functions to calculate thermodynamic properties of air. Journal of Open Source Software, 4(33), 1137, https://doi.org/10.21105/joss.01137"
 )

--- a/src/r/inst/PSYCHROLIB_AUTHORS.txt
+++ b/src/r/inst/PSYCHROLIB_AUTHORS.txt
@@ -1,0 +1,7 @@
+Authors ordered by first contribution
+
+Didier Thevenard
+David Meyer
+Daniel Gosnell
+Michael Lass <michael.lass@upb.de>
+Hongyuan Jia <hongyuan.jia@bears-berkeley.sg>

--- a/src/r/tools/deploy.R
+++ b/src/r/tools/deploy.R
@@ -49,7 +49,7 @@ update_license <- function () {
     }
 
     lic <- c(
-        paste("Year:", year),
+        paste("YEAR:", year),
         paste("COPYRIGHT HOLDER:", auth)
     )
 


### PR DESCRIPTION
First submission try, still got a NOTE. CRAN maintainer replied:

```
Thanks, we see:

   License components with restrictions and base license permitting such:
     MIT + file LICENSE
   File 'LICENSE':
     Year: 2018-2020
     COPYRIGHT HOLDER: The PsychroLib Contributors

Please use YEAR: 2018-2020

   Found the following (possibly) invalid DOIs:
     DOI: doi.org/10.21105/joss.01137
       From: inst/CITATION
       Message: Invalid DOI

The DOI used in the doi markup is only 10.21105/joss.01137

Please fix and resubmit.
```

According CRAN policy, year field in MIT LICENSE should start as `YEAR` not `Year`. Also, DOI prefix should be removed.

This PR modified `src/r/tools/deploy.R` and `src/r/inst/CITATION` accordingly.