### PR TITLE
Updated C# Testing Project to .NET 5.0

### DIFF
--- a/tests/c_sharp/PsychroLib.Tests/PsychroLib.Tests.csproj
+++ b/tests/c_sharp/PsychroLib.Tests/PsychroLib.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses #73
This fixes the the CI build breaking due to the netcoreapp3.0 not being supported by the latest `dotnet-sdk 5.0.102` snap.  This does not affect the Nuget packaging at all, so no version bump is required.