### PR TITLE
Remove LazyData in DESCRIPTION

### DIFF
--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -14,7 +14,7 @@ Description:
     <https://github.com/psychrometrics/psychrolib> library which contains
     functions to enable the calculation properties of moist and dry air in both
     metric (SI) and imperial (IP) systems of units. References: Meyer, D. and
-    Thevenard, D (2019) <doi.org:10.21105/joss.01137>.
+    Thevenard, D (2019) <doi:10.21105/joss.01137>.
 Depends:
     R (>= 3.0.0)
 Imports:

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -3,12 +3,12 @@ Type: Package
 Title: Psychrometric Properties of Moist and Dry Air
 Version: 2.5.2
 Authors@R: c(
-      person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
+      person("Hongyuan", "Jia", email = "hongyuanjia@outlook.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
              comment = "Authors listed in inst/PSYCHROLIB_AUTHORS.txt"),
       person(family = "ASHRAE", role = c("cph"),
              comment = "Copyright 2017 ASHRAE Handbook Fundamentals (https://www.ashrae.org) for equations and coefficients published ASHRAE Handbook Fundamentals Chapter 1."))
-Maintainer: Hongyuan Jia <hongyuan.jia@bears-berkeley.sg>
+Maintainer: Hongyuan Jia <hongyuanjia@outlook.com>
 Description:
     Implementation of 'PsychroLib'
     <https://github.com/psychrometrics/psychrolib> library which contains

--- a/src/r/DESCRIPTION
+++ b/src/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: psychrolib
 Type: Package
 Title: Psychrometric Properties of Moist and Dry Air
-Version: 2.5.1
+Version: 2.5.2
 Authors@R: c(
       person("Hongyuan", "Jia", email = "hongyuan.jia@bears-berkeley.sg", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0075-8183")),
       person(family = "The PsychroLib Contributors", role = c("ctb", "cph"),
@@ -27,5 +27,4 @@ URL: https://github.com/psychrometrics/psychrolib
 BugReports: https://github.com/psychrometrics/psychrolib/issues
 LinkingTo: Rcpp
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.0.2

--- a/src/r/tools/deploy.R
+++ b/src/r/tools/deploy.R
@@ -72,6 +72,22 @@ update_links <- function () {
     readme <- gsub("(\\[.+\\])\\(LICENSE.txt\\)", "\\1(LICENSE)", readme)
     readme <- gsub("(\\[.+\\])\\((.+\\.md)\\)", paste0("\\1(", repo, "/blob/master/\\2)"), readme)
     writeLines(readme, "README.md")
+
+    # update all links in packages
+    message("Check URLs and update if necessary")
+    check_install_urlchecker()
+    suppressMessages(urlchecker::url_update(), "cliMessage")
+    NULL
+}
+
+check_install_urlchecker <- function () {
+    check_devtools()
+
+    # check and install urlchecker if necessary
+    if (!require("urlchecker", quietly = TRUE)) {
+        message("'urlchecker' package is needed but not installed. Try to install it via GitHub")
+        devtools::install_github("r-lib/urlchecker")
+    }
 }
 
 check_devtools <- function () {


### PR DESCRIPTION
### Pull request overview

- Update maintainer email
- CRAN recently added [a new check](https://github.com/wch/r-source/commit/3280ff02a2567cc9d05ba10b7d143f88aeb4bb1b#diff-ccd3a8e040f4129bac68a5ffadcf628df73ad9ddbdbd67cdacbdf45c0079c2e2R2560) on the `Lazydata` field in `DESCRIPTION` and will [issue a NOTE](https://cran.r-project.org/web/checks/check_results_psychrolib.html) if `LazyData` is specified without a `data` directory. This PR removes the `LazyData` field to make sure the R package is compatible with CRAN requirements.

```
Version: 2.5.1
Check: LazyData
Result: NOTE
     'LazyData' is specified without a 'data' directory
```