### PR TITLE
Attempt to fix a command aliasing issue relating to #83

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     fi
     if [[ "$C_SHARP" ]]; then
       cd $TRAVIS_BUILD_DIR
-      cd src/c_sharp && dotnet-sdk.dotnet test
+      cd src/c_sharp && dotnet test
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     fi
     if [[ "$C_SHARP" ]]; then
       cd $TRAVIS_BUILD_DIR
-      cd src/c_sharp && dotnet test
+      cd src/c_sharp && sudo dotnet test
     fi
 
 deploy:


### PR DESCRIPTION
Fix for the failing dotnet unit tests.  Appears to be an aliasing issue with the `dotnet-sdk.dotnet` command