### PR TITLE
Fix numpy.f2py.compile issue by using subprocess.run (resolves #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '16'
 
       - name: Install python dependecies
-        run: pip install cffi numba pytest
+        run: pip install cffi numba pytest charset-normalizer
       - name: Install JS dependecies
         run: cd $GITHUB_WORKSPACE/tests/js && npm install
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -71,7 +71,7 @@ PsychroLib is automatically tested at each commit using continuous integration. 
 There are a number of dependencies required to run the tests that need to be installed first. From you command prompt, navigate to the `psychrolib` folder and type the following (I assume that pip and python are for version 3.6 or greater):
 
 ```
-pip install numpy m2r cffi pytest
+pip install numpy m2r cffi pytest charset-normalizer
 cd tests/js && npm install
 cd ../..
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
-import numpy.f2py as f2py
+import subprocess
 import cffi
 
 
@@ -21,9 +21,8 @@ import psychrolib
 # Compile and import Fortran library
 #########################################################
 PATH_TO_LIB = Path(__file__).parents[1] / 'src' / 'fortran' / 'psychrolib.f90'
-with open(str(PATH_TO_LIB), 'rb') as fid:
-    source = fid.read()
-f2py.compile(source , modulename='psychrolib_fortran', extension='.f90')
+subprocess.run(['f2py', '-c', '-m', 'psychrolib_fortran', str(PATH_TO_LIB)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
 import psychrolib_fortran
 psyf = psychrolib_fortran.psychrolib
 


### PR DESCRIPTION
This PR addresses the issue #103, where removed `numpy.f2py.compile` causes test failures. The problem is resolved by using `subprocess.run` to directly call `f2py`. Additionally, charset-normalizer is included in the dependent packages, for `f2py` to correctly recognize the encoding.

The CI test failures (Sphinx build error and C# test error) should not be related to this PR. 